### PR TITLE
Add Education for Sustainable Development publication to projects

### DIFF
--- a/src/pages/projects.mdx
+++ b/src/pages/projects.mdx
@@ -44,6 +44,9 @@ columns={4}
         <a href="https://academic.oup.com/ismecommun/article/5/1/ycaf089/8152717">Upcycling human excrement: the gut microbiome to soil microbiome axis</a>
     </FeatureItem>
     <FeatureItem>
+        <a href="https://doi.org/10.1080/0047231X.2025.2472138"><img src="/src/assets/images/Ed-Sust-Dev.png" alt="Education for Sustainable Development publication thumbnail" /></a>
+    </FeatureItem>
+    <FeatureItem>
         <a href="https://www.youtube.com/watch?v=KWofEZkbZDw"> Meilander and Caporaso 
         discuss CML's interest and work in this area on the Spotlight on Climate radio show produced by NAZCCA and Sunnyside radio 101.5 FM.</a>
     </FeatureItem>


### PR DESCRIPTION
Closing this PR — the publication was already included in PR #19 (`claude/add-vermicompost-images-Uc47P`) with a nicer thumbnail layout. Also fixed a broken image import filename there (`Education for Sustainable Development.png` → `Ed-Sust-Dev.png`).